### PR TITLE
adding cgo parameter flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The `name` option sets a prefix for the build filenames. In compression mode, th
 #### ☉ option: **dest**
 The `dest` option sets the output directory for the build files. This should be a relative directory without leading `./`.
 
-#### ☉ option: **dest**
-The `cgo` option sets if you want go to use cgo when building the binary. The default behavior of golang is to build with cgo. setting this option to `'false'` will disable cgo when building the binaries.
+#### ☉ option: **cgo**
+The `cgo` option sets if you want go to use cgo when building the binary. The default behavior of golang is to build with [cgo on native systems](https://pkg.go.dev/cmd/cgo#:~:text=The%20cgo%20tool%20is%20enabled,to%200%20to%20disable%20it). setting this option to `'false'` will disable cgo when building the binaries, setting it to `'true'` will enable CGO when building the binaries.
 
 
 ## Build Artifacts

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
             name: 'program'
             compress: 'true'
             dest: 'dist'
+            cgo: 'false'
 ```
 
 #### ☉ option: **platforms**
@@ -49,6 +50,9 @@ The `name` option sets a prefix for the build filenames. In compression mode, th
 
 #### ☉ option: **dest**
 The `dest` option sets the output directory for the build files. This should be a relative directory without leading `./`.
+
+#### ☉ option: **dest**
+The `cgo` option sets if you want go to use cgo when building the binary. The default behavior of golang is to build with cgo. setting this option to `'false'` will disable cgo when building the binaries.
 
 
 ## Build Artifacts

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Flags to pass to the Go linker.'
     default: ''
     required: false
+  cgo:
+    description: "Enable CGO"
+    default: 'true'
+    required: false
 
 # action runner (golang:latest image)
 runs:

--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,8 @@ inputs:
     default: ''
     required: false
   cgo:
-    description: "Enable CGO"
-    default: 'true'
+    description: "Enable or Disable CGO"
+    default: ''
     required: false
 
 # action runner (golang:latest image)

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -39,7 +39,7 @@ func copyFile(src, dest string) {
 /*************************************/
 
 // build the package for a platform
-func build(packageName, destDir string, platform map[string]string, ldflags string, compress bool) {
+func build(packageName, destDir string, platform map[string]string, ldflags string, compress bool, cgo bool) {
 
 	// platform config
 	platformKernel := platform["kernel"]
@@ -84,10 +84,17 @@ func build(packageName, destDir string, platform map[string]string, ldflags stri
 	// generate `go build` command
 	buildCmd := exec.Command("go", buildOptions...)
 
+	cgoValue := 0
+
+	if cgo {
+		cgoValue = 1
+	}
+
 	// set environment variables
 	buildCmd.Env = append(os.Environ(), []string{
 		fmt.Sprintf("GOOS=%s", platformKernel),
 		fmt.Sprintf("GOARCH=%s", platformArch),
+		fmt.Sprintf("CGO_ENABLED=%d", cgoValue),
 	}...)
 
 	// execute `go build` command
@@ -168,6 +175,7 @@ func main() {
 	inputPlatforms := os.Getenv("INPUT_PLATFORMS")
 	inputPackage := os.Getenv("INPUT_PACKAGE")
 	inputCompress := os.Getenv("INPUT_COMPRESS")
+	inputCGO := os.Getenv("INPUT_CGO")
 	inputDest := os.Getenv("INPUT_DEST")
 	inputLdflags := os.Getenv("INPUT_LDFLAGS")
 
@@ -186,6 +194,11 @@ func main() {
 		compress = true
 	}
 
+	cgo := false
+	if strings.ToLower(inputCGO) == "true" {
+		compress = true
+	}
+
 	// for each platform, execute `build` function
 	for _, platform := range platforms {
 
@@ -199,7 +212,7 @@ func main() {
 		}
 
 		// execute `build` function
-		build(packageName, destDir, platformMap, inputLdflags, compress)
+		build(packageName, destDir, platformMap, inputLdflags, compress, cgo)
 	}
 
 	/*------------*/


### PR DESCRIPTION
Go by default will build with CGO enabled when building on native systems where it is expected to work. 
https://pkg.go.dev/cmd/cgo#:~:text=The%20cgo%20tool%20is%20enabled,to%200%20to%20disable%20it.

I would like to add a parameter flag which will disable CGO when building no matter if it could be supported natively.

This is useful when building artifacts that will not run on systems that will not have the c  bindings present for example docker containers running binaries.