### PR TITLE
Bump Golang & Debian Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Debian GNU/Linux 11 (1.17.13-bullseye)
-FROM 1.17.3-bullseye
+FROM golang:1.17.3-bullseye
 
 # copy entrypoint file
 COPY entrypoint.go /usr/bin/entrypoint.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Debian GNU/Linux 10 (1.13.10-buster)
-FROM golang:1.16-buster
+# Debian GNU/Linux 11 (1.17.13-bullseye)
+FROM 1.17.3-bullseye
 
 # copy entrypoint file
 COPY entrypoint.go /usr/bin/entrypoint.go


### PR DESCRIPTION
# Description of Changes
* bump Golang version to 1.17.3
* bump Debian to 11.1 (Bullseye)

# Motivation
* bumping Golang version successfully resolves build issues for debian/arm64 (#5)